### PR TITLE
Fix: Cargo.toml package name parsing support for windows newlines

### DIFF
--- a/src/command-validator.ts
+++ b/src/command-validator.ts
@@ -69,7 +69,7 @@ export async function validateDocumentUri(
 
   if (options.isCrate) {
     const cargoContent = fs.readFileSync(path.join(options.cargoPath, "Cargo.toml")).toString();
-    const regex = new RegExp('(?:[package](?:(?:.|\n)*)(?:name.*=.*"(?<cargoname>.*)"))');
+    const regex = new RegExp('(?:[package](?:(?:.|\r|\n)*?)(?:name.*?=.*?"(?<cargoname>.*?)"))');
     let result = cargoContent.match(regex);
 
     if (result && result.groups && result.groups.cargoname) {


### PR DESCRIPTION
Currently the `Cargo.toml` will not be parsed correctly when windows newlines (`\r`) are present.

This is fixed by adding the `\r` to the regex for parsing the name out of the `Cargo.toml`.  